### PR TITLE
fix: aws cli deployment permissions

### DIFF
--- a/.github/workflows/tests_unit.yaml
+++ b/.github/workflows/tests_unit.yaml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/publish.yaml'
       - '.github/workflows/publish-release.yaml'
       - '**/docs/**'
+      - '**/scripts/**'
 
 jobs:
   unit_test:

--- a/packages/explorer/scripts/deploy.sh
+++ b/packages/explorer/scripts/deploy.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-aws s3 sync dist s3://$EXPLORER_BUCKET_NAME
+aws s3 sync dist s3://$EXPLORER_BUCKET_NAME --acl public-read


### PR DESCRIPTION
Uses `--acl` flag